### PR TITLE
Fix for Gnome-shell 3.26

### DIFF
--- a/nautilus-copypath.py
+++ b/nautilus-copypath.py
@@ -5,12 +5,19 @@
 # See LICENSE file for more information.
 #----------------------------------------------------------------------------------------
 
-import os
 import gi
-gi.require_version('Nautilus', '3.0')
-gi.require_version('Gtk', '3.0')
+try:
+    gi.require_version('Gtk', '3.0')
+    gi.require_version('Nautilus', '3.0')
+except Exception as e:
+    print(e)
+    exit(-1)
+import os
 
-from gi.repository import Nautilus, GObject, Gtk, Gdk
+from gi.repository import GObject
+from gi.repository import Gtk
+from gi.repository import Gdk
+from gi.repository import Nautilus
 
 class CopyPathExtension(GObject.GObject, Nautilus.MenuProvider):
     def __init__(self):

--- a/nautilus-copypath.py
+++ b/nautilus-copypath.py
@@ -41,10 +41,8 @@ class CopyPathExtension(GObject.GObject, Nautilus.MenuProvider):
             tip='Copy the file\'s full path to the clipboard'
         )
         item_copy_path.connect('activate', self.__copy_path, files)
-        items.append(item_copy_path)
 
-        return [ item_copy_path, ]
+        return item_copy_path,
 
     def get_background_items(self, window, files):
         return self.get_file_items(window, files)
-

--- a/nautilus-copywinpath.py
+++ b/nautilus-copywinpath.py
@@ -5,12 +5,19 @@
 # See LICENSE file for more information.
 #----------------------------------------------------------------------------------------
 
-import os
 import gi
-gi.require_version('Nautilus', '3.0')
-gi.require_version('Gtk', '3.0')
+try:
+    gi.require_version('Gtk', '3.0')
+    gi.require_version('Nautilus', '3.0')
+except Exception as e:
+    print(e)
+    exit(-1)
+import os
 
-from gi.repository import Nautilus, GObject, Gtk, Gdk
+from gi.repository import GObject
+from gi.repository import Gtk
+from gi.repository import Gdk
+from gi.repository import Nautilus
 
 class CopySambaToWindowsPathExtension(GObject.GObject, Nautilus.MenuProvider):
     def __init__(self):
@@ -39,4 +46,3 @@ class CopySambaToWindowsPathExtension(GObject.GObject, Nautilus.MenuProvider):
 
     def get_background_items(self, window, files):
         return self.get_file_items(window, files)
-


### PR DESCRIPTION
I was not able to run this extension on gnome-shell 3.26 without this fix (commit 75f64da).

Commit 4ba8d88 avoids warnings "sys:1: PyGIWarning: Nautilus was imported without specifying a version first. Use gi.require_version('Nautilus', '3.0') before import to ensure that the right version gets loaded."