### PR TITLE
This commit adds automatically escaped parenthesis

### DIFF
--- a/nautilus-copypath.py
+++ b/nautilus-copypath.py
@@ -18,7 +18,7 @@ class CopyPathExtension(GObject.GObject, Nautilus.MenuProvider):
 
     def __sanitize_path(self, path):
         # Replace actual spaces with Linux-compatible spaces
-        return path.replace(' ', '\\ ')
+        return path.replace(' ', '\\ ').replace('(', '\(').replace(')', '\)')
 
     def __copy_files_path(self, menu, files):
         pathstr = None


### PR DESCRIPTION
Just one change. This commit will properly escape parenthesis in copied paths. Fixes #3. 

_Note:_ I closed a prior pull request to fix a noob mistake when I initially made the commit message, it caused the screenshot.png to 'rewrite' resulting in two changed files instead of just the one, **nautilus-copypath.py**. Everything here should be all good. Cheers. 