### PR TITLE
Add single quotes to path, avoid escaping troublesome meta-characters

### DIFF
--- a/nautilus-copypath.py
+++ b/nautilus-copypath.py
@@ -17,8 +17,8 @@ class CopyPathExtension(GObject.GObject, Nautilus.MenuProvider):
         self.clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
 
     def __sanitize_path(self, path):
-        # Replace spaces and parenthesis with their Linux-compatible equivalents. 
-        return path.replace(' ', '\\ ').replace('(', '\\(').replace(')', '\\)')
+        # Add single quotes to path, avoid troublesome metacharacters
+        return "'" + path.replace("'", "'\\''") + "'"
 
     def __copy_files_path(self, menu, files):
         pathstr = None


### PR DESCRIPTION
I kept running into random characters that require escaping. With the goal of keeping things as simple as possible, instead add single quotes to path to avoid troublesome meta-characters altogether.  

Not sure if you would prefer this approach rather than escaping _xyz_ , but I have been using this commit for a couple months without issue. It also results in more readable paths. 