### PR TITLE
Gnome 3.32.1 & Nautilus 3.32.0 - Needed to log out & log in for it to show

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ cp nautilus-copypath.py ~/.local/share/nautilus-python/extensions/
 cp nautilus-copywinpath.py ~/.local/share/nautilus-python/extensions/
 ```
 
-Restart Nautilus and the extension will be available.
+Restart Nautilus and the extension will be available. If that doesn't work try logging out and back in. 


### PR DESCRIPTION
Restarting Nautilus did not get it to show in menu, but a log out/log in did get it to show. 