### PR TITLE
Change the order of imports to get rid of a warning.

### DIFF
--- a/nautilus-copypath.py
+++ b/nautilus-copypath.py
@@ -5,7 +5,6 @@
 # Distributed under the GPL-v3+ license. See LICENSE for more information
 # ----------------------------------------------------------------------------------------
 
-from gi.repository import Nautilus, GObject, Gdk, Gtk
 import os
 from platform import system
 
@@ -18,6 +17,8 @@ gi.require_versions({
     'Gdk': '3.0' if gi_version_major == 3 else '4.0',
     'Gtk': '3.0' if gi_version_major == 3 else '4.0'
 })
+
+from gi.repository import Nautilus, GObject, Gdk, Gtk
 
 
 class CopyPathExtensionSettings:


### PR DESCRIPTION
I just noticed that the program always shows a PyGIWarning when running in terminal. I moved the `gi` import above the Gtk nad Gdk imports to remove the warnings.

Those are the warnings which were shown:
```
PyGIWarning: Gdk was imported without specifying a version first. Use gi.require_version('Gdk', '4.0') before import to ensure that the right version gets loaded.
  from gi.repository import Nautilus, GObject, Gdk, Gtk
PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '4.0') before import to ensure that the right version gets loaded.
  from gi.repository import Nautilus, GObject, Gdk, Gtk
  ```